### PR TITLE
prevent page number overlap

### DIFF
--- a/resources/views/meeting.blade.php
+++ b/resources/views/meeting.blade.php
@@ -8,7 +8,7 @@
                 {{ $meeting->name }}
             </div>
             <div>
-                @if ($meeting->name !== $meeting->location)
+                @if ($meeting->location && $meeting->location !== $meeting->name)
                     {{ $meeting->location }},
                 @endif
                 {{ $meeting->address }}

--- a/resources/views/pdf.blade.php
+++ b/resources/views/pdf.blade.php
@@ -1,3 +1,7 @@
+@php
+    $page_margin = 18;
+    $footer_height = 20;
+@endphp
 <!DOCTYPE html>
 <html lang="en">
 
@@ -6,7 +10,11 @@
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <style type="text/css">
         @page {
-            margin: 18px;
+            margin: {{ $page_margin }}px;
+
+            @if ($numbering !== false)
+                margin-bottom: {{ $footer_height + $page_margin }}px;
+            @endif
         }
 
         body {
@@ -99,8 +107,8 @@
         }
 
         footer {
-            bottom: 0;
-            height: 20px;
+            bottom: -{{ $footer_height }}px;
+            height: {{ $footer_height }}px;
             left: 0;
             position: fixed;
             right: 0;


### PR DESCRIPTION
when footer is present, add 20px to bottom page margin
when location name is not present, don't show floating comma

before:
![before](https://github.com/code4recovery/pdf/assets/1551689/4691c68a-de10-486f-b2de-d82e40ef25a8)
[directory.pdf](https://github.com/code4recovery/pdf/files/11689562/directory.pdf)


after:
![after](https://github.com/code4recovery/pdf/assets/1551689/c5598253-f96b-49fc-a5e5-da3e115c9ce1)
[directory(1).pdf](https://github.com/code4recovery/pdf/files/11689578/directory.1.pdf)

closes #39 