### PR TITLE
Add option to add a legend header or footer

### DIFF
--- a/app/Http/Controllers/Controller.php
+++ b/app/Http/Controllers/Controller.php
@@ -100,6 +100,7 @@ class Controller extends BaseController
         ];
         $options = [
             'legend' => 'Meeting Types Legend',
+            'date' => 'Print date',
         ];
         $languages = [
             'en' => 'English',

--- a/app/Http/Controllers/Controller.php
+++ b/app/Http/Controllers/Controller.php
@@ -100,7 +100,6 @@ class Controller extends BaseController
         ];
         $options = [
             'legend' => 'Meeting Types Legend',
-            'date' => 'Print date',
         ];
         $languages = [
             'en' => 'English',
@@ -132,6 +131,8 @@ class Controller extends BaseController
         $stream = request('mode') === 'stream';
         $options = request('options', []);
         $group_by = request('group_by', 'day-region');
+        $legend_header = request('legend_header', '');
+        $legend_footer = request('legend_footer', '');
         $types = self::$types;
 
         //process data
@@ -409,7 +410,7 @@ class Controller extends BaseController
         }
 
         //output PDF
-        $pdf = PDF::loadView('pdf', compact('days', 'font', 'numbering', 'group_by', 'types_in_use', 'regions', 'types', 'options'))
+        $pdf = PDF::loadView('pdf', compact('days', 'font', 'numbering', 'group_by', 'types_in_use', 'regions', 'types', 'options', 'legend_header', 'legend_footer'))
             ->setPaper([0, 0, $width, $height]);
 
         return ($stream) ? $pdf->stream() : $pdf->download('directory.pdf');

--- a/resources/views/home.blade.php
+++ b/resources/views/home.blade.php
@@ -117,6 +117,24 @@
                             </div>
                         @endforeach
                     </div>
+                    <div class="col-md-6 mb-4">
+                    </div>
+                    <div class="col-md-6 mb-4">
+                        <label class="form-label fw-bold">Legend Header (optional)</label>
+                        {!! Form::textarea('legend_header', null, [
+                                  'id' => 'legend_header',
+                                  'rows' => 4,
+                                  'cols' => 30,
+                         ]) !!}
+                    </div>
+                    <div class="col-md-6 mb-4">
+                        <label class="form-label fw-bold">Legend Footer (optional)</label>
+                        {!! Form::textarea('legend_footer', null, [
+                                  'id' => 'legend_footer',
+                                  'rows' => 4,
+                                  'cols' => 30,
+                         ]) !!}
+                    </div>
                     <div class="col-12 text-center my-4">
                         {{ html()->submit('Generate')->class('btn btn-primary btn-lg px-4') }}
                     </div>

--- a/resources/views/home.blade.php
+++ b/resources/views/home.blade.php
@@ -121,19 +121,11 @@
                     </div>
                     <div class="col-md-6 mb-4">
                         <label class="form-label fw-bold">Legend Header (optional)</label>
-                        {!! Form::textarea('legend_header', null, [
-                                  'id' => 'legend_header',
-                                  'rows' => 4,
-                                  'cols' => 30,
-                         ]) !!}
+                        {{ html()->textarea('legend_header') }}
                     </div>
                     <div class="col-md-6 mb-4">
                         <label class="form-label fw-bold">Legend Footer (optional)</label>
-                        {!! Form::textarea('legend_footer', null, [
-                                  'id' => 'legend_footer',
-                                  'rows' => 4,
-                                  'cols' => 30,
-                         ]) !!}
+                        {{ html()->textarea('legend_footer') }}
                     </div>
                     <div class="col-12 text-center my-4">
                         {{ html()->submit('Generate')->class('btn btn-primary btn-lg px-4') }}

--- a/resources/views/legend.blade.php
+++ b/resources/views/legend.blade.php
@@ -1,4 +1,7 @@
 <div class="legend">
+    @if ($legend_header)
+        <div class="legend-header">{{ $legend_header }}</div>
+    @endif
     <h1>Meeting Types</h1>
     @foreach ($types_in_use as $type)
         <div class="type-row">
@@ -6,4 +9,7 @@
             <span>{{ $types[$type] }}</span>
         </div>
     @endforeach
+    @if ($legend_footer)
+        <div class="legend-footer">{{ $legend_footer }}</div>
+    @endif
 </div>

--- a/resources/views/pdf.blade.php
+++ b/resources/views/pdf.blade.php
@@ -66,6 +66,11 @@
             border-bottom: none;
         }
 
+        .date {
+            font-size: 8px;
+            text-align: right;
+        }
+
         .legend>div span {
             display: inline-block;
         }
@@ -129,7 +134,13 @@
 
 <body>
     @if ($numbering !== false)
-        <footer></footer>
+        <footer>
+            @if (in_array('date', $options))
+                <div class="date">
+                    Printed {{ date('Y-m-d') }}
+                </div>
+            @endif
+        </footer>
     @endif
     <main>
         @if (in_array('legend', $options))

--- a/resources/views/pdf.blade.php
+++ b/resources/views/pdf.blade.php
@@ -66,9 +66,12 @@
             border-bottom: none;
         }
 
-        .date {
+        .legend_header {
+            font-size: 12px;
+        }
+
+        .legend_footer {
             font-size: 8px;
-            text-align: right;
         }
 
         .legend>div span {
@@ -134,17 +137,11 @@
 
 <body>
     @if ($numbering !== false)
-        <footer>
-            @if (in_array('date', $options))
-                <div class="date">
-                    Printed {{ date('Y-m-d') }}
-                </div>
-            @endif
-        </footer>
+        <footer></footer>
     @endif
     <main>
         @if (in_array('legend', $options))
-            @include('legend', compact('types_in_use', 'types'))
+            @include('legend', compact('types_in_use', 'types', 'legend_header', 'legend_footer'))
         @endif
         @if ($group_by === 'day-region')
             @foreach ($days as $day => $regions)


### PR DESCRIPTION
## Description

This adds a very simple option to add a header or footer to the legend. I use this to add the printed date.

## Form changes

<img width="685" alt="Screenshot 2023-06-17 at 7 07 22 AM" src="https://github.com/code4recovery/pdf/assets/1244341/3f0217d1-4174-4214-949d-37a1123abd3d">

(note that the image above also includes the "compact" option suggested in https://github.com/code4recovery/pdf/pull/45)

## Output changes

<img width="730" alt="Screenshot 2023-06-17 at 7 09 49 AM" src="https://github.com/code4recovery/pdf/assets/1244341/37d9a4c7-38e6-496f-8b40-88d5d2c68934">

