### PR TITLE
Add option to print more compact (skip page break between days)

### DIFF
--- a/app/Http/Controllers/Controller.php
+++ b/app/Http/Controllers/Controller.php
@@ -100,6 +100,7 @@ class Controller extends BaseController
         ];
         $options = [
             'legend' => 'Meeting Types Legend',
+            'compact' => 'Compact format',
         ];
         $languages = [
             'en' => 'English',

--- a/resources/views/pdf.blade.php
+++ b/resources/views/pdf.blade.php
@@ -52,7 +52,11 @@
             .day
         @endif
             {
+            @if (in_array('compact', $options))
+            padding-bottom: 10px;
+            @else
             page-break-after: always;
+            @endif
         }
 
         .legend>div {


### PR DESCRIPTION
## Description

This adds an option to print more compactly, skipping the page break between days.

This saves a couple of pages of printing, which saves hundreds of dollars!