### PR TITLE
Re-compile all changes for "Translate meeting types legend #60 (issue…

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -5,8 +5,9 @@
     "keywords": ["framework", "laravel"],
     "license": "MIT",
     "require": {
-        "php": "^8.1.0",
+        "php": "^8.2.0",
         "barryvdh/laravel-dompdf": "^2.0.1",
+        "code4recovery/spec": "^1.0",
         "guzzlehttp/guzzle": "^7.6.1",
         "laravel/framework": "^10.0",
         "laravel/sanctum": "^3.2",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "a0d7759ee46ee330bd16815e45e68328",
+    "content-hash": "4fc3345279fbfa9e996588103acd100e",
     "packages": [
         {
             "name": "barryvdh/laravel-dompdf",
@@ -203,6 +203,46 @@
                 }
             ],
             "time": "2022-02-21T13:15:14+00:00"
+        },
+        {
+            "name": "code4recovery/spec",
+            "version": "v1.0.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/anchovie91471/c4r-spec.git",
+                "reference": "de373cadce2f4763743f624a57944c5d62cf1aa4"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/anchovie91471/c4r-spec/zipball/de373cadce2f4763743f624a57944c5d62cf1aa4",
+                "reference": "de373cadce2f4763743f624a57944c5d62cf1aa4",
+                "shasum": ""
+            },
+            "require": {
+                "ext-json": "*",
+                "php": ">=7.4"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Code4Recovery\\": "src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Code for Recovery"
+                }
+            ],
+            "description": "The goal of the Meeting Guide API is help sync information about AA meetings. It was developed for the Meeting Guide app, but it is non-proprietary and other systems are encouraged to make use of it.",
+            "support": {
+                "issues": "https://github.com/anchovie91471/c4r-spec/issues",
+                "source": "https://github.com/anchovie91471/c4r-spec/tree/v1.0.0"
+            },
+            "time": "2024-01-27T03:43:02+00:00"
         },
         {
             "name": "dflydev/dot-access-data",
@@ -9522,7 +9562,7 @@
     "prefer-stable": true,
     "prefer-lowest": false,
     "platform": {
-        "php": "^8.1.0"
+        "php": "^8.2.0"
     },
     "platform-dev": [],
     "plugin-api-version": "2.3.0"

--- a/resources/views/legend.blade.php
+++ b/resources/views/legend.blade.php
@@ -1,5 +1,5 @@
 <div class="legend">
-    <h1>Meeting Types</h1>
+    <span class="heading">{{ $meeting_types_heading }}</span>
     @foreach ($types_in_use as $type)
         <div class="type-row">
             <span class="type">{{ $type }}</span>

--- a/resources/views/pdf.blade.php
+++ b/resources/views/pdf.blade.php
@@ -6,8 +6,11 @@
 <html lang="en">
 
 <head>
-    <meta charset="utf-8" />
+    <meta http-equiv="Content-Type" content="text/html; charset=utf-8"/>
     <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link href="https://fonts.googleapis.com/css2?family=Noto+Sans+JP:wght@100..900&family=Zen+Old+Mincho:wght@400;700&display=swap" rel="stylesheet">
     <style type="text/css">
         @page {
             margin: {{ $page_margin }}px;
@@ -25,14 +28,17 @@
             font-size: 12px;
         }
 
-        h1 {
+        .heading {
+            font-weight: bold;
+            display: block;
             border-bottom: 0.5px solid black;
             font-size: 16px;
             margin: 0 0 10px;
             padding-bottom: 4px;
         }
 
-        h3 {
+        .subheading {
+            display: block;
             font-weight: normal;
             font-size: 11px;
             margin: 1px 0 3px;
@@ -133,11 +139,11 @@
         @if ($group_by === 'day-region')
             @foreach ($days as $day => $regions)
                 <div class="day">
-                    <h1>{{ $day }}</h1>
+                    <span class="heading">{{ $day }}</span>
                     @foreach ($regions as $region => $meetings)
                         <div class="region">
                             @if ($region)
-                                <h3>{{ $region }}</h3>
+                                <span class="subheading">{{ $region }}</span>
                             @endif
                             @foreach ($meetings as $meeting)
                                 @include('meeting', compact('meeting', 'region'))
@@ -149,11 +155,11 @@
         @elseif ($group_by === 'region-day')
             @foreach ($regions as $region => $days)
                 <div class="region">
-                    <h1>{{ $region }}</h1>
+                    <span class="heading">{{ $region }}</span>
                     @foreach ($days as $day => $meetings)
                         <div class="day">
                             @if ($day)
-                                <h3>{{ $day }}</h3>
+                                <span class="subheading">{{ $day }}</span>
                             @endif
                             @foreach ($meetings as $meeting)
                                 @include('meeting', compact('meeting', 'region'))
@@ -165,7 +171,7 @@
         @else
             @foreach ($days as $day => $meetings)
                 <div class="day">
-                    <h1>{{ $day }}</h1>
+                    <span class="heading">{{ $day }}</span>
                     @foreach ($meetings as $meeting)
                         @include('meeting', compact('meeting'))
                     @endforeach

--- a/storage/fonts/.gitignore
+++ b/storage/fonts/.gitignore
@@ -1,0 +1,2 @@
+*
+!.gitignore


### PR DESCRIPTION
Re-compile all changes for "Translate meeting types legend #60" && "Support new language types #59 (PR)"

 Controller.php
 - Replaced hard coded $types array with Code4Recovery\Spec composer package
 - Added a $debug variable to allow PDF blade template to be viewed in browser
 - Added translation string for "Meeting Types" so the heading on the legend is also translated
 - Added japanese & Svenska translation entries to $strings

 legend.blade.php
  - Replaced hard coded "Meeting Types" with translated $meeting_types_heading variable
  - `<h1>` & `<h3>` tags were causing difficulty with new fonts. Switched to <span> tags with same styling

pdf.blade.php
  - Changed meta charset tag to be inline with current standards
  - Added Google fonts to support japanese characters
  - `<h1>` & `<h3>` tags were causing difficulty with new fonts. Switched to <span> tags with same styling

storage/fonts/.gitignore
 - Added to allow DomPDF to fetch, save, & attach custom fonts to PDF