### PR TITLE
Add case-insensitive and natural sorting for regions

### DIFF
--- a/app/Http/Controllers/Controller.php
+++ b/app/Http/Controllers/Controller.php
@@ -424,11 +424,16 @@ class Controller extends BaseController
         });
 
         if ($group_by === 'region-day') {
-            $meetings = $meetings->sortBy([['regions_formatted', 'asc'],['day', 'asc'], ['time', 'asc']]);
+            $meetings = $meetings->sortBy('time')
+                ->sortBy('day')
+                ->sortBy('regions_formatted', SORT_NATURAL | SORT_FLAG_CASE);
         } elseif ($group_by === 'day-region') {
-            $meetings = $meetings->sortBy([['day', 'asc'],['regions_formatted', 'asc'], ['time', 'asc']]);
+            $meetings = $meetings->sortBy('time')
+                ->sortBy('regions_formatted', SORT_NATURAL | SORT_FLAG_CASE)
+                ->sortBy('day');
         } else {
-            $meetings = $meetings->sortBy([['day', 'asc'], ['time', 'asc']]);
+            $meetings = $meetings->sortBy('time')
+                ->sortBy('day');
         }
 
         $types_in_use = array_unique($meetings->pluck('types')->reduce(function ($carry, $item) {


### PR DESCRIPTION

This PR updates the meeting sorting logic to sort regions alphabetically in a natural and case-insensitive manner, preventing lowercase region names from being sorted separately from uppercase ones.

Changes:

Modified the `sortBy()` calls for regions_formatted to use `SORT_NATURAL | SORT_FLAG_CASE` flags
Applies to both "Region → Day" and "Day → Region" grouping modes
Maintains the original multi-level sort order (region/day/time combinations)

In order to be able to pass the flags correctly to `sortBy()`  the multi-level sort order must be done by chaining `sortBy()` rather than one single call.


Why:
Previously, regions were sorted case-sensitively, which could result in inconsistent ordering where "downtown" would appear after "Westside" instead of being properly alphabetized. Natural case-insensitive sorting provides a better user experience in the generated PDFs.

